### PR TITLE
Add Atbash cipher implementation

### DIFF
--- a/atbash-cipher/README.md
+++ b/atbash-cipher/README.md
@@ -1,0 +1,53 @@
+# Atbash Cipher
+
+Welcome to Atbash Cipher on Exercism's Bash Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Create an implementation of the Atbash cipher, an ancient encryption system created in the Middle East.
+
+The Atbash cipher is a simple substitution cipher that relies on transposing all the letters in the alphabet such that the resulting alphabet is backwards.
+The first letter is replaced with the last letter, the second with the second-last, and so on.
+
+An Atbash cipher for the Latin alphabet would be as follows:
+
+```text
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: zyxwvutsrqponmlkjihgfedcba
+```
+
+It is a very weak cipher because it only has one possible key, and it is a simple mono-alphabetic substitution cipher.
+However, this may not have been an issue in the cipher's time.
+
+Ciphertext is written out in groups of fixed length, the traditional group size being 5 letters, leaving numbers unchanged, and punctuation is excluded.
+This is to make it harder to guess things based on word boundaries.
+All text will be encoded as lowercase letters.
+
+## Examples
+
+- Encoding `test` gives `gvhg`
+- Encoding `x123 yes` gives `c123b vh`
+- Decoding `gvhg` gives `test`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
+
+## Source
+
+### Created by
+
+- @sjwarner-bp
+
+### Contributed to by
+
+- @bkhl
+- @budmc29
+- @glennj
+- @guygastineau
+- @IsaacG
+- @kotp
+- @Smarticles101
+- @ZapAnton
+
+### Based on
+
+Wikipedia - https://en.wikipedia.org/wiki/Atbash

--- a/atbash-cipher/atbash_cipher.bats
+++ b/atbash-cipher/atbash_cipher.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+load bats-extra
+
+# local version: 1.2.0.0
+
+# encode
+
+@test "encode yes" {
+  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh encode "yes"
+  assert_success
+  assert_output "bvh"
+}
+
+@test "encode no" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh encode "no"
+  assert_success
+  assert_output "ml"
+}
+
+@test "encode OMG" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh encode "OMG"
+  assert_success
+  assert_output "lnt"
+}
+
+@test "encode spaces" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh encode "O M G"
+  assert_success
+  assert_output "lnt"
+}
+
+@test "encode mindblowingly" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh encode "mindblowingly"
+  assert_success
+  assert_output "nrmwy oldrm tob"
+}
+
+@test "encode numbers" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh encode "Testing,1 2 3, testing."
+  assert_success
+  assert_output "gvhgr mt123 gvhgr mt"
+}
+
+@test "encode deep thought" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh encode "Truth is fiction."
+  assert_success
+  assert_output "gifgs rhurx grlm"
+}
+
+@test "encode all the letters" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh encode "The quick brown fox jumps over the lazy dog."
+  assert_success
+  assert_output "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+}
+
+# decode
+
+@test "decode exercism" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh decode "vcvix rhn"
+  assert_success
+  assert_output "exercism"
+}
+
+@test "decode a sentence" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh decode "zmlyh gzxov rhlug vmzhg vkkrm thglm v"
+  assert_success
+  assert_output "anobstacleisoftenasteppingstone"
+}
+
+@test "decode numbers" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh decode "gvhgr mt123 gvhgr mt"
+  assert_success
+  assert_output "testing123testing"
+}
+
+@test "decode all the letters" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh decode "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+  assert_success
+  assert_output "thequickbrownfoxjumpsoverthelazydog"
+}
+
+@test "decode with too many spaces" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh decode "vc vix    r hn"
+  assert_success
+  assert_output "exercism"
+}
+
+@test "decode with no spaces" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash atbash_cipher.sh decode "zmlyhgzxovrhlugvmzhgvkkrmthglmv"
+  assert_success
+  assert_output "anobstacleisoftenasteppingstone"
+}
+

--- a/atbash-cipher/atbash_cipher.sh
+++ b/atbash-cipher/atbash_cipher.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+declare -A code_table=(
+  [a]=z [b]=y [c]=x [d]=w [e]=v [f]=u [g]=t [h]=s [i]=r [j]=q [k]=p [l]=o [m]=n
+  [n]=m [o]=l [p]=k [q]=j [r]=i [s]=h [t]=g [u]=f [v]=e [w]=d [x]=c [y]=b [z]=a)
+
+declare -rl phrase=${2//[^[:alnum:]]/}
+declare -i len=${#phrase}
+
+for ((i = 0; i < len; i++)); do
+  symbol=${phrase:i:1}
+  if [[ $symbol =~ [[:alpha:]] ]]; then
+    symbol=${code_table[$symbol]}
+  fi
+  result+=$symbol
+done
+
+if [[ $1 == encode ]]; then
+  echo "$result" | sed -e 's/.\{5\}/& /g; s/ *$//'
+else
+  echo "$result"
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an Atbash cipher tool for encoding and decoding text in Bash.
	- Added support for grouping encoded output in blocks of five letters, preserving numbers, and ignoring punctuation.
- **Documentation**
	- Added a comprehensive README explaining the Atbash cipher, usage instructions, and examples.
- **Tests**
	- Implemented a full test suite to verify correct encoding and decoding behavior, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->